### PR TITLE
"Version 2.1" - Updated to Swift 4.1 syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,102 @@
+#####
+# OS X temporary files that should never be committed
 .DS_Store
+*.swp
+*.lock
+profile
 
+#####
+# DotEnv files
+.env
+
+####
+# Xcode temporary files that should never be committed
+*~.nib
+
+####
+# Objective-C/Swift specific
+*.hmap
+*.ipa
+
+####
+# Xcode build files
+DerivedData/
+build/
+Builds/
+
+#####
+# Xcode private settings (window sizes, bookmarks, breakpoints, custom executables, smart groups)
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3
+
+####
+# Xcode 4
+xcuserdata
+!xcschemes
+# Xcode 4
+*.moved-aside
+
+####
+# XCode 4 workspaces - more detailed
+!xcshareddata
+!default.xcworkspace
+*.xcworkspacedata
+
+
+####
+# Xcode 5
+*.xccheckout
+*.xcuserstate
+
+####
+# Xcode 7
+*.xcscmblueprint
+
+####
+# AppCode
+.idea/
+
+####
+# Other Xcode files
+profile
+*.hmap
+*.ipa
+
+####
+# CocoaPods
+Pods/
+!Podfile
+!Podfile.lock
+
+####
+# Carthage
+Carthage/Build.rbenv-vars
+!Cartfile
+!Cartfile.private
+!Cartfile.resolved
+
+####
+# Fastlane
+# Temporary profiling data
+/fastlane/report.xml
+# Deliver temporary error output
+/fastlane/Error*.png
+# Deliver temporary preview output
+/fastlane/Preview.html
+# Snapshot generated screenshots
+/fastlane/screenshots/*/*-portrait.png
+/fastlane/screenshots/*/*-landscape.png
+/fastlane/screenshots/screenshots.html
+# Frameit generated screenshots
+/fastlane/screenshots/*/*-portrait_framed.png
+/fastlane/screenshots/*/*-landscape_framed.png
+
+####
+# rbenv
+.rbenv-vars

--- a/CryptoCompatibility.xcodeproj/project.pbxproj
+++ b/CryptoCompatibility.xcodeproj/project.pbxproj
@@ -404,14 +404,16 @@
 					D7B9F15C1DFC4ACC00CD7A39 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = D9ACCH3T4Y;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 					D7B9F17C1DFCDB3B00CD7A39 = {
 						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 					E405DE831713084C007165B9 = {
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0940;
 					};
 				};
 			};
@@ -620,7 +622,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -651,7 +652,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.oopers.UnitTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -689,7 +689,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -720,7 +719,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -775,7 +773,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -828,7 +826,7 @@
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -840,7 +838,6 @@
 				PRODUCT_NAME = CryptoCompatibility;
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -851,7 +848,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = CryptoCompatibility;
 				SWIFT_OBJC_BRIDGING_HEADER = "Operations/Tool-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/CryptoCompatibility.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CryptoCompatibility.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Sample code project: CryptoCompatibility
-Version: 2.0
+Version: 2.1
 
 IMPORTANT:  This Apple software is supplied to you by Apple
 Inc. ("Apple") in consideration of your agreement to the following

--- a/Operations/QCCAESCryptor.swift
+++ b/Operations/QCCAESCryptor.swift
@@ -138,12 +138,12 @@ final class QCCAESCryptor: Operation {
             err = kCCParamError
         }
         let ivPointer = ivData?.withUnsafeBytes {(ivBytes: UnsafePointer<UInt8>) -> UnsafeMutableRawPointer in
-            let ptr = UnsafeMutableRawPointer.allocate(bytes: ivData!.count, alignedTo: 1)
+            let ptr = UnsafeMutableRawPointer.allocate(byteCount: ivData!.count, alignment: 1)
             ptr.initializeMemory(as: UInt8.self, from: ivBytes, count: ivData!.count)
             return ptr
         }
         defer {
-            ivPointer?.deallocate(bytes: ivData!.count, alignedTo: 1)
+            ivPointer?.deallocate()
         }
         
         if err == kCCSuccess {
@@ -151,7 +151,7 @@ final class QCCAESCryptor: Operation {
             
             let err32 = self.keyData.withUnsafeBytes {keyBytes in
                 self.inputData.withUnsafeBytes {bytes in
-                    result!.withUnsafeMutableBytes {mutableBytes in
+                    result!.withUnsafeMutableBytes { [count = result!.count] mutableBytes in
                         CCCrypt(
                             self.op,
                             CCAlgorithm(kCCAlgorithmAES128),
@@ -159,7 +159,7 @@ final class QCCAESCryptor: Operation {
                             keyBytes, self.keyData.count,
                             ivPointer,                                  // will be NULL if ivData is nil
                             bytes, self.inputData.count,
-                            mutableBytes, result!.count,
+                            mutableBytes, count,
                             &resultLength
                         )
                     }

--- a/Operations/QCCAESPadBigCryptor.swift
+++ b/Operations/QCCAESPadBigCryptor.swift
@@ -176,8 +176,8 @@ final class QCCAESPadBigCryptor: Operation {
         // an empty input buffer.
         
         if self.error == nil {
-            let bytesRead = inputBuffer.withUnsafeMutableBytes {mutableBytes in
-                self.inputStream.read(mutableBytes, maxLength: inputBuffer.count)
+            let bytesRead = inputBuffer.withUnsafeMutableBytes { [count = inputBuffer.count] mutableBytes in
+                self.inputStream.read(mutableBytes, maxLength: count)
             }
             if bytesRead >= 0 {
                 inputBuffer.count = bytesRead
@@ -241,19 +241,19 @@ final class QCCAESPadBigCryptor: Operation {
         if self.error == nil {
             if inputBuffer.count != 0 {
                 err = inputBuffer.withUnsafeBytes{bytes in
-                    outputBuffer.withUnsafeMutableBytes{mutableBytes in
+                    outputBuffer.withUnsafeMutableBytes{ [count = outputBuffer.count] mutableBytes in
                         CCCryptorUpdate(
                             cryptor,
                             bytes, inputBuffer.count,
-                            mutableBytes, outputBuffer.count,
+                            mutableBytes, count,
                             &bytesToWrite)
                     }
                 }
             } else {
-                err = outputBuffer.withUnsafeMutableBytes{mutableBytes in
+                err = outputBuffer.withUnsafeMutableBytes{ [count = outputBuffer.count] mutableBytes in
                     CCCryptorFinal(
                         cryptor,
-                        mutableBytes, outputBuffer.count,
+                        mutableBytes, count,
                         &bytesToWrite)
                 }
             }
@@ -282,7 +282,7 @@ final class QCCAESPadBigCryptor: Operation {
         // Create the cryptor.
         
         let ivPointer = ivData?.withUnsafeBytes {(ivBytes: UnsafePointer<UInt8>) -> UnsafeMutableRawPointer in
-            let ptr = UnsafeMutableRawPointer.allocate(bytes: ivData!.count, alignedTo: 1)
+            let ptr = UnsafeMutableRawPointer.allocate(byteCount: ivData!.count, alignment: 1)
             ptr.initializeMemory(as: UInt8.self, from: ivBytes, count: ivData!.count)
             return ptr
         }

--- a/Operations/QCCAESPadCryptor.swift
+++ b/Operations/QCCAESPadCryptor.swift
@@ -155,12 +155,12 @@ final class QCCAESPadCryptor: Operation {
             err = kCCParamError
         }
         let ivPointer = ivData?.withUnsafeBytes {(ivBytes: UnsafePointer<UInt8>) -> UnsafeMutableRawPointer in
-            let ptr = UnsafeMutableRawPointer.allocate(bytes: ivData!.count, alignedTo: 1)
+            let ptr = UnsafeMutableRawPointer.allocate(byteCount: ivData!.count, alignment: 1)
             ptr.initializeMemory(as: UInt8.self, from: ivBytes, count: ivData!.count)
             return ptr
         }
         defer {
-            ivPointer?.deallocate(bytes: ivData!.count, alignedTo: 1)
+            ivPointer?.deallocate()
         }
         
         if err == kCCSuccess {
@@ -180,7 +180,7 @@ final class QCCAESPadCryptor: Operation {
             
             let err32 = keyData.withUnsafeBytes {keyBytes in
                 inputData.withUnsafeBytes {bytes in
-                    result!.withUnsafeMutableBytes {mutableBytes in
+                    result!.withUnsafeMutableBytes { [count = result!.count] mutableBytes in
                         CCCrypt(
                             self.op,
                             CCAlgorithm(kCCAlgorithmAES128),
@@ -188,7 +188,7 @@ final class QCCAESPadCryptor: Operation {
                             keyBytes, self.keyData.count,
                             ivPointer,                                  // will be NULL if ivData is nil
                             bytes, self.inputData.count,
-                            mutableBytes, result!.count,
+                            mutableBytes, count,
                             &resultLength
                         )
                     }

--- a/Operations/QCCBase64Encode.swift
+++ b/Operations/QCCBase64Encode.swift
@@ -64,7 +64,7 @@ class QCCBase64Encode: Operation {
         // Our old code use to always add a trailing LF unless the input was empty,
         // and our unit test relies on that, so we replicate it here.
         
-        if output.characters.count > 0 && !output.hasSuffix("\n") {
+        if output.count > 0 && !output.hasSuffix("\n") {
             output += "\n"
         }
         self.outputString = output

--- a/Operations/QCCPBKDF2SHAKeyDerivation.swift
+++ b/Operations/QCCPBKDF2SHAKeyDerivation.swift
@@ -257,7 +257,7 @@ class QCCPBKDF2SHAKeyDerivation: Operation {
         
         if err == kCCSuccess {
             let err32 = saltData.withUnsafeBytes{(saltPtr: UnsafePointer<UInt8>) in
-                result.withUnsafeMutableBytes{(mutableBytes: UnsafeMutablePointer<UInt8>) in
+                result.withUnsafeMutableBytes{ [count = result.count] (mutableBytes: UnsafeMutablePointer<UInt8>) in
                     CCKeyDerivationPBKDF(
                         CCPBKDFAlgorithm(kCCPBKDF2),
                         passwordString, passwordUTFLength,
@@ -265,7 +265,7 @@ class QCCPBKDF2SHAKeyDerivation: Operation {
                         ccAlgorithm,
                         UInt32(self.actualRounds),
                         mutableBytes,
-                        result.count
+                        count
                     )
                 }
             }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CryptoCompatibility
 
-2.0
+2.1
 
 CryptoCompatibility shows how to do common cryptographic operations using Apple APIs such that the results match other well-known cryptographic toolkits, most notably OpenSSL.
 
@@ -49,9 +49,9 @@ If you run the tool with no parameters it will print a list of supported subcomm
 
     $ ./CryptoCompatibility
     usage: CryptoCompatibility [-v] subcommand
-
+    
     Subcommands:
-
+    
     base64-encode [-l] file
     …
 
@@ -198,11 +198,13 @@ If you find any problems with this sample, or you’d like to suggest improvemen
 
 2.0 (Sep 2016) was a significant update to support the new unified crypto APIs added in macOS 10.12 and iOS 10.  It removed support for MD5 digests and RSA without padding; see the “Removed Operations” section for details.  It added support for SHA2 (as a digest and in other places, like PBKDF2, where a digest is used implicitly).  It also added support for OAEP padding in the RSA cryptor.  Finally, there was the usual update to use the latest tools and techniques.
 
+2.1 (Aug 2018) was an update to Swift 4.1 syntax (builds on Xcode 9.4.1).
+
 Share and Enjoy
 
 Apple Developer Technical Support  
 Core OS/Hardware
 
-15 Sep 2016
+12 Aug 2018
 
 Copyright (C) 2016 Apple Inc. All rights reserved.

--- a/Tool/OOPUtils/GetoptLong.swift
+++ b/Tool/OOPUtils/GetoptLong.swift
@@ -45,7 +45,7 @@ open class GetoptLong {
             }
             self.shortopts[key] = (key, hasArg, argIsOptional, key)
             
-            shortopts.characters.formIndex(after: &index)
+            shortopts.formIndex(after: &index)
         }
         for longopt in longopts {
             self.longopts[longopt.name] = longopt
@@ -78,7 +78,7 @@ open class GetoptLong {
     }
     
     private func processLongOption(_ i: Int, _ arg: String) -> Int {
-        let argName = arg.substring(from: arg.index(arg.startIndex, offsetBy: 2))
+		let argName = String(arg[arg.index(arg.startIndex, offsetBy: 2)...])
         if let opt = longopts[argName] {
             if opt.hasArg {
                 if i + 1 < argv.count && !isOption(argv[i + 1]) {
@@ -102,15 +102,15 @@ open class GetoptLong {
     }
     
     private func processShortOption(_ i: Int, _ arg: String) -> Int {
-        let argName = arg.substring(from: arg.index(after: arg.startIndex))
+		let argName = String(arg[arg.index(after: arg.startIndex)...])
         //temporal restriction
-        if argName.characters.count > 1 {
-            for index in argName.characters.indices {
+        if argName.count > 1 {
+            for index in argName.indices {
                 let optChar = String(argName[index])
                 if let opt = shortopts[optChar] {
                     if opt.hasArg {
                         if argName.index(after: index) < argName.endIndex {
-                            optargs[opt.key] = (argName.substring(from: argName.index(after: index)), false)
+							optargs[opt.key] = (String(argName[argName.index(after: index)...]), false)
                             return 0    //skip 0 arg
                         } else if i + 1 < argv.count && !isOption(argv[i + 1]) {
                             optargs[opt.key] = (argv[i + 1], false)

--- a/Tool/QHex.swift
+++ b/Tool/QHex.swift
@@ -58,13 +58,13 @@ class QHex {
         var result: Data? = nil
         var cursor = hexString.startIndex
         let limit = hexString.endIndex
-        if hexString.characters.count % 2 == 0 {
+        if hexString.count % 2 == 0 {
             result = Data()
             
             while cursor != limit {
                 
                 let next = hexString.index(cursor, offsetBy: 2)
-                guard let thisByte = UInt8(hexString.substring(with: cursor..<next), radix: 16) else {
+                guard let thisByte = UInt8(hexString[cursor..<next], radix: 16) else {
                     result = nil
                     break
                 }

--- a/Tool/QToolCommand.swift
+++ b/Tool/QToolCommand.swift
@@ -164,7 +164,7 @@ class QToolCommand {
     
     //### Do not override this property directly. Instead, override `optionFuncs` and `optionFuncsWithArg` properly.
     var commandOptions: String {
-        return type(of: self).optionFuncs.keys.joined() +
+		return type(of: self).optionFuncs.keys.joined(separator: ":") +
             type(of: self).optionFuncsWithArg.keys.map{$0+":"}.joined()
     }
     class var optionFuncs: [String: (QToolCommand)->()->Void] {

--- a/UnitTest/KeyDerivationOperationsTests.swift
+++ b/UnitTest/KeyDerivationOperationsTests.swift
@@ -122,7 +122,7 @@ class KeyDerivationOperationsTests: XCTestCase {
         ToolCommon.shared.synchronouslyRun(operation: op)
         let timeTaken = Date.timeIntervalSinceReferenceDate - startTime
         XCTAssertNil(op.error)
-        XCTAssertEqualWithAccuracy(timeTaken, 0.5, accuracy: 0.2) //### `0.2` seems not enough for our environment
+        XCTAssertEqual(timeTaken, 0.5, accuracy: 0.2) //### `0.2` seems not enough for our environment
         XCTAssertEqual(op.actualRounds, actualRounds)
         XCTAssertEqual(op.derivedKeyData!, derivedKey)
     }


### PR DESCRIPTION
"Version 2.1" - Updated to Swift 4.1 syntax (builds on Xcode 9.4.1). Unit test testPBKDF2Error() is still failing but was also failing on the previous Swift 3 master branch, so I haven't attempted to address fixing it at this point.